### PR TITLE
Add RedHat 6-7 support.

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -126,6 +126,37 @@ java_package:
             name: java-1_7_0-openjdk-devel
           8:
             name: java-1_8_0-openjdk-devel
+    RedHat:
+      "6":
+        jre:
+          6:
+            name: java-1.6.0-openjdk
+          7:
+            name: java-1.7.0-openjdk
+          8:
+            name: java-1.8.0-openjdk
+        jdk:
+          6:
+            name: java-1.6.0-openjdk-devel
+          7:
+            name: java-1.7.0-openjdk-devel
+          8:
+            name: java-1.8.0-openjdk-devel
+      "7":
+        jre:
+          6:
+            name: java-1.6.0-openjdk
+          7:
+            name: java-1.7.0-openjdk
+          8:
+            name: java-1.8.0-openjdk
+        jdk:
+          6:
+            name: java-1.6.0-openjdk-devel
+          7:
+            name: java-1.7.0-openjdk-devel
+          8:
+            name: java-1.8.0-openjdk-devel
     Ubuntu:
       "16":
         jre:


### PR DESCRIPTION
Much like Debian is sort of like Ubuntu, but not quite, CentOS is like RedHat. Adding the RedHat variable makes the ansible_distribution variable happy. Otherwise it throws an undefined variable error.