### PR TITLE
Add support for Red Hat (openjdk 6-8,11) and CentOS (openjdk 11)

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -38,6 +38,7 @@ galaxy_info:
     - centos
     - debian
     - fedora
+    - rhel
     - java
     - oracle
     - openjdk

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,12 +5,14 @@ _java_openjdk_package:
     6:
       default: java-1.6.0-openjdk
       CentOS: java-1.6.0-openjdk
+      RedHat: java-1.6.0-openjdk
     7:
       default: java-1.7.0-openjdk
       Alpine: openjdk7-jre-base
       Archlinux: jre7-openjdk
       CentOS: java-1.7.0-openjdk
       openSUSE Leap: java-1_7_0-openjdk
+      RedHat: java-1.7.0-openjdk
     8:
       default: java-1.8.0-openjdk
       Alpine: openjdk8-jre-base
@@ -21,6 +23,7 @@ _java_openjdk_package:
       Gentoo: jre
       Ubuntu: openjdk-8-jre
       openSUSE Leap: java-1_8_0-openjdk
+      RedHat: java-1.8.0-openjdk
     9:
       Archlinux: jre9-openjdk
       Fedora: java-9-openjdk
@@ -30,9 +33,11 @@ _java_openjdk_package:
       Debian: openjdk-10-jre
       Ubuntu: openjdk-10-jre
     11:
+      CentOS: java-11-openjdk
       Debian: openjdk-11-jre
       Fedora: java-11-openjdk
       Ubuntu: openjdk-11-jre
+      RedHat: java-11-openjdk
     12:
       Ubuntu: openjdk-12-jre
     13:
@@ -41,12 +46,14 @@ _java_openjdk_package:
     6:
       default: java-1.6.0-openjdk-devel
       CentOS: java-1.6.0-openjdk-devel
+      RedHat: java-1.6.0-openjdk-devel
     7:
       default: java-1.7.0-openjdk-devel
       Alpine: openjdk7
       Archlinux: jdk7-openjdk
       CentOS: java-1.7.0-openjdk-devel
       openSUSE Leap: java-1_7_0-openjdk-devel
+      RedHat: java-1.7.0-openjdk-devel
     8:
       default: java-1.8.0-openjdk-devel
       Alpine: openjdk8
@@ -57,6 +64,7 @@ _java_openjdk_package:
       Gentoo: jdk
       Ubuntu: openjdk-8-jdk
       openSUSE Leap: java-1_8_0-openjdk-devel
+      RedHat: java-1.8.0-openjdk-devel
     9:
       Archlinux: jdk9-openjdk
       Fedora: java-9-openjdk-devel
@@ -66,9 +74,11 @@ _java_openjdk_package:
       Debian: openjdk-10-jdk
       Ubuntu: openjdk-10-jdk
     11:
+      CentOS: java-11-openjdk-devel
       Debian: openjdk-11-jdk
       Fedora: java-11-openjdk-devel
       Ubuntu: openjdk-11-jdk
+      RedHat: java-11-openjdk-devel
     12:
       Ubuntu: openjdk-12-jdk
     13:


### PR DESCRIPTION
**Description**
Added names of packages for 
- CentOS and OpenJDK 11
- Red Hat and OpenJDK 6-8, 11

**Testing**
Tests for CentOS and added OpenJDK were performed by running `molecule test --scenario-name centos-latest` with the modified [file ansible-role-java/molecule/centos-latest/molecule.yml](https://github.com/robertdebock/ansible-role-java/blob/master/molecule/centos-latest/molecule.yml#L18) - the line  the line 8 was set to `../resources/playbook-11.yml`.