### PR TITLE
#12 java version

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -72,7 +72,7 @@ _java_openjdk_package:
     13:
       default: openjdk-13-jdk
 
-java_openjdk_package: "{{ _java_openjdk_package[java_type][java_default_version | int][ansible_distribution] | default(_java_openjdk_package[java_type][java_default_version | int]['default'] | default([] )) }}"
+java_openjdk_package: "{{ _java_openjdk_package[java_type][java_version | int][ansible_distribution] | default(_java_openjdk_package[java_type][java_default_version | int]['default'] | default([] )) }}"
 
 _java_package:
   oracle:
@@ -97,4 +97,4 @@ _java_package:
 
 java_oracle_package: "{{ _java_oracle_package[java_type][java_version][java_format] | default([] ) }}"
 
-java_oracle_directory: "{{ _java_oracle_package[java_type][java_version]['directory] }}"
+java_oracle_directory: "{{ _java_oracle_package[java_type][java_version]['directory'] }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -95,6 +95,6 @@ _java_package:
         rpm: jdk-10.0.2_linux-x64_bin.rpm
         directory: jdk-10.0.2
 
-java_oracle_package: "{{ _java_oracle_package[java_type][java_version][java_format] | default([] ) }}"
+java_oracle_package: "{{ _java_oracle_package[java_type][java_version | int][java_format] | default([] ) }}"
 
-java_oracle_directory: "{{ _java_oracle_package[java_type][java_version]['directory'] }}"
+java_oracle_directory: "{{ _java_oracle_package[java_type][java_version | int]['directory'] }}"


### PR DESCRIPTION
---
name: java_version variable not used when installing an openjdk #12
about: Description inside Issue #12

---

**Describe the change**
Role will use java_version variable defined by user.
PR also adds casting java_version variable to integer.

**Testing**
Testen on: Debian 11, Ubuntu 20.04.
